### PR TITLE
Fixed birth and death years in Master.csv.

### DIFF
--- a/core/Master.csv
+++ b/core/Master.csv
@@ -5507,7 +5507,7 @@ floribr01,1970,5,21,USA,SC,Charleston,,,,,,,Bryce,Florie,Bryce Bettencourt,185,7
 floripe01,1986,12,10,D.R.,La Romana,La Romana,,,,,,,Pedro,Florimon,Pedro Alexander,185,74,B,R,2011-09-10,2016-10-02,florp001,floripe01
 florody01,1990,12,27,USA,CA,Merced,,,,,,,Dylan,Floro,Dylan Lee,175,74,L,R,2016-07-07,2016-08-14,,florody01
 flowebe01,1927,6,15,USA,NC,Goldsboro,2009,2,18,USA,NC,Wilson,Ben,Flowers,Bennett,195,76,R,R,1951-09-29,1956-09-21,flowb101,flowebe01
-flowedi01,1850,,,USA,PA,Philadelphia,1982,10,5,USA,PA,Philadelphia,Dickie,Flowers,Charles Richard,,,,,1871-06-03,1872-06-12,flowd101,flowedi01
+flowedi01,1850,,,USA,PA,Philadelphia,1892,10,5,USA,PA,Philadelphia,Dickie,Flowers,Charles Richard,,,,,1871-06-03,1872-06-12,flowd101,flowedi01
 floweja01,1902,3,16,USA,MD,Cambridge,1962,12,27,USA,FL,Clearwater,Jake,Flowers,D'Arcy Raymond,170,71,R,R,1923-09-07,1934-08-02,flowj101,floweja01
 flowety01,1986,1,24,USA,GA,Roswell,,,,,,,Tyler,Flowers,Cole Tyler,245,76,R,R,2009-09-03,2016-10-02,flowt001,flowety01
 flowewe01,1913,8,13,USA,AR,Vanndale,1988,12,31,USA,AR,Wynne,Wes,Flowers,Charles Wesley,190,73,L,L,1940-08-08,1944-06-12,floww101,flowewe01
@@ -8497,7 +8497,7 @@ johnsba01,1950,1,3,USA,CA,Torrance,,,,,,,Bart,Johnson,Clair Barth,190,77,R,R,196
 johnsba99,1865,1,5,USA,OH,Norwalk,1931,3,28,USA,MO,St. Louis,Ban,Johnson,Byron Bancroft,,,,,,,,johnsba99
 johnsbe01,1931,5,15,USA,SC,Greenwood,,,,,,,Ben,Johnson,Benjamin Franklin,190,74,R,R,1959-09-06,1960-06-12,johnb107,johnsbe01
 johnsbe02,1981,6,18,USA,TN,Memphis,,,,,,,Ben,Johnson,Benjamin Joseph,200,73,R,R,2005-06-26,2007-06-10,johnb003,johnsbe02
-johnsbi01,1961,9,28,USA,NJ,,1942,7,17,USA,PA,Chester,Lefty,Johnson,William F.,167,,L,L,1884-06-27,1892-04-27,johnb106,johnsbi01
+johnsbi01,1861,9,28,USA,NJ,,1942,7,17,USA,PA,Chester,Lefty,Johnson,William F.,167,,L,L,1884-06-27,1892-04-27,johnb106,johnsbi01
 johnsbi02,1892,10,18,USA,IL,Chicago,1950,11,5,USA,CA,Los Angeles,Bill,Johnson,William Lawrence,170,71,L,R,1916-09-22,1917-07-30,johnb109,johnsbi02
 johnsbi03,1918,8,30,USA,NJ,Montclair,2006,6,20,USA,GA,Augusta,Billy,Johnson,William Russell,180,70,R,R,1943-04-22,1953-05-10,johnb108,johnsbi03
 johnsbi04,1960,10,6,USA,DE,Wilmington,,,,,,,Bill,Johnson,William Charles,205,77,R,R,1983-09-06,1984-09-29,johnb001,johnsbi04


### PR DESCRIPTION
1)  Playerid johnsbi01's birth year was listed as 1961. According to
Retrosheet, his birth year is 1861
(http://www.retrosheet.org/boxesetc/J/Pjohnb106.htm). This was originally
reported in bug #36. This commit corrects his birth year to 1861.

2)  Master.csv had Dickie Flowers' (flowedi01) death date as 1982-10-05. Per Retrosheet's
player webpage for him (http://www.retrosheet.org/boxesetc/F/Pflowd101.htm),
he died on 1892-10-05. This commit corrects his death year to 1892.