### PR TITLE
Add lgid value for Nelson Cruz 2017 Outstanding DH Award 2017

### DIFF
--- a/core/AwardsPlayers.csv
+++ b/core/AwardsPlayers.csv
@@ -6212,7 +6212,7 @@ turneju01,NLCS MVP,2017,NL,Y,Co-MVP
 tayloch03,NLCS MVP,2017,NL,Y,Co-MVP
 moustmi01,Comeback Player of the Year,2017,AL,,
 zimmery01,Comeback Player of the Year,2017,NL,,
-cruzne02,Outstanding DH Award,2017,,,
+cruzne02,Outstanding DH Award,2017,AL,,
 kimbrcr01,Reliever of the Year Award,2017,AL,,
 janseke01,Reliever of the Year Award,2017,NL,,
 sanchga02,TSN All-Star,2017,AL,,C


### PR DESCRIPTION
Noticed that the League ID was missing from Nelson Cruz's Outstanding DH Award in 2017.  

Not sure if it's a big deal or not, just thought I'd err on the side of bringing it up.